### PR TITLE
lsp: warn about unused variables

### DIFF
--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -18,7 +18,11 @@ pub struct Analysis {
 pub fn analyze(env: &EnvDefs, root: ast::Root) -> Analysis {
     let (scope_info, mut errors, warnings) = scope::analyze(root.clone());
     errors.extend(checks::run_all(env, root));
-    Analysis { scope_info, errors, warnings }
+    Analysis {
+        scope_info,
+        errors,
+        warnings,
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -12,12 +12,13 @@ pub mod scope;
 pub struct Analysis {
     pub scope_info: ScopeInfo,
     pub errors: Vec<AnalysisError>,
+    pub warnings: Vec<AnalysisWarning>,
 }
 
 pub fn analyze(env: &EnvDefs, root: ast::Root) -> Analysis {
-    let (scope_info, mut errors) = scope::analyze(root.clone());
+    let (scope_info, mut errors, warnings) = scope::analyze(root.clone());
     errors.extend(checks::run_all(env, root));
-    Analysis { scope_info, errors }
+    Analysis { scope_info, errors, warnings }
 }
 
 #[derive(Debug, Clone)]
@@ -42,3 +43,24 @@ impl fmt::Display for AnalysisError {
 }
 
 impl Error for AnalysisError {}
+
+#[derive(Debug, Clone)]
+pub struct AnalysisWarning {
+    pub message: String,
+    pub range: TextRange,
+}
+
+impl AnalysisWarning {
+    pub fn new(message: impl Into<String>, range: TextRange) -> Self {
+        Self {
+            message: message.into(),
+            range,
+        }
+    }
+}
+
+impl fmt::Display for AnalysisWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -58,9 +58,3 @@ impl AnalysisWarning {
         }
     }
 }
-
-impl fmt::Display for AnalysisWarning {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.message.fmt(f)
-    }
-}

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -45,8 +45,8 @@ impl ScopeAnalyzer {
 
     fn finish(self) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
         assert!(self.parent_scopes.is_empty());
-        let mut warnings: Vec<AnalysisWarning> = Vec::new();
-        for (_, v) in &self.var_syms {
+        let mut warnings = Vec::new();
+        for v in self.var_syms.values() {
             if !v.used && !v.name.ends_with("_") && let Some(decl_range) = v.decl_range {
                 warnings.push(AnalysisWarning::new(format!("unused variable {}", v.name), decl_range));
             }
@@ -347,8 +347,7 @@ impl ScopeAnalyzer {
         let name = var_use.name();
         match self.lookup_var(name) {
             Some(id) => {
-                let sym = &mut self.var_syms[id];
-                sym.used = true;
+                self.var_syms[id].used = true;
                 self.set_referent(var_use, id);
             }
             None => self.error(format!("undefined variable {name}"), var_use.text_range()),

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -8,9 +8,9 @@ use yag_template_syntax::ast;
 use yag_template_syntax::ast::{Action, AstNode, AstToken};
 
 use super::{Scope, ScopeId, ScopeInfo, VarSymbol, VarSymbolId};
-use crate::AnalysisError;
+use crate::{AnalysisError, AnalysisWarning};
 
-pub fn analyze(root: ast::Root) -> (ScopeInfo, Vec<AnalysisError>) {
+pub fn analyze(root: ast::Root) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
     let mut s = ScopeAnalyzer::new(root.text_range());
     // The variable $ is predefined as the initial context data.
     s.declare_var("$", root.text_range().start(), None);
@@ -43,10 +43,16 @@ impl ScopeAnalyzer {
         }
     }
 
-    fn finish(self) -> (ScopeInfo, Vec<AnalysisError>) {
+    fn finish(self) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
         assert!(self.parent_scopes.is_empty());
+        let mut warnings: Vec<AnalysisWarning> = Vec::new();
+        for (_, v) in &self.var_syms {
+            if !v.used && !v.name.ends_with("_") && let Some(decl_range) = v.decl_range {
+                warnings.push(AnalysisWarning::new(format!("unused variable {}", v.name), decl_range));
+            }
+        }
         let info = ScopeInfo::new(self.var_syms, self.resolved_var_uses, self.scopes);
-        (info, self.errors)
+        (info, self.errors, warnings)
     }
 
     fn error(&mut self, message: impl Into<String>, range: TextRange) {
@@ -89,6 +95,7 @@ impl ScopeAnalyzer {
             name: name.clone(),
             visible_from,
             decl_range,
+            used: false,
         });
 
         let top = &mut self.scopes[self.top_scope];
@@ -339,7 +346,11 @@ impl ScopeAnalyzer {
     fn resolve_var_use(&mut self, var_use: ast::Var) {
         let name = var_use.name();
         match self.lookup_var(name) {
-            Some(id) => self.set_referent(var_use, id),
+            Some(id) => {
+                let sym = &mut self.var_syms[id];
+                sym.used = true;
+                self.set_referent(var_use, id);
+            }
             None => self.error(format!("undefined variable {name}"), var_use.text_range()),
         }
     }

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -47,7 +47,10 @@ impl ScopeAnalyzer {
         assert!(self.parent_scopes.is_empty());
         let mut warnings = Vec::new();
         for v in self.var_syms.values() {
-            if !v.used && !v.name.ends_with("_") && let Some(decl_range) = v.decl_range {
+            if !v.used
+                && !v.name.ends_with("_")
+                && let Some(decl_range) = v.decl_range
+            {
                 warnings.push(AnalysisWarning::new(format!("unused variable {}", v.name), decl_range));
             }
         }

--- a/crates/yag-template-analysis/src/scope/mod.rs
+++ b/crates/yag-template-analysis/src/scope/mod.rs
@@ -64,6 +64,7 @@ pub struct VarSymbol {
     /// Within its scope, the variable is accessible after this offset.
     pub visible_from: TextSize,
     pub decl_range: Option<TextRange>,
+    pub used: bool,
 }
 
 #[derive(Debug)]

--- a/crates/yag-template-lsp/src/provider/diagnostics.rs
+++ b/crates/yag-template-lsp/src/provider/diagnostics.rs
@@ -9,11 +9,15 @@ pub(crate) async fn publish(sess: &Session, uri: &Url) -> anyhow::Result<()> {
 
     let syntax_error_diags = doc.parse.errors.iter().map(|err| diag_for_syntax_error(&doc, err));
     let analysis_error_diags = doc.analysis.errors.iter().map(|err| diag_for_analysis_error(&doc, err));
-    let analysis_warning_diags = doc.analysis.warnings.iter().map(|warning| diag_for_analysis_warning(&doc, warning));
+    let analysis_warning_diags = doc
+        .analysis
+        .warnings
+        .iter()
+        .map(|warning| diag_for_analysis_warning(&doc, warning));
     let all_diags = syntax_error_diags
-                    .chain(analysis_error_diags)
-                    .chain(analysis_warning_diags)
-                    .collect();
+        .chain(analysis_error_diags)
+        .chain(analysis_warning_diags)
+        .collect();
 
     let version = Default::default();
     sess.client
@@ -38,7 +42,7 @@ fn diag_for_analysis_warning(doc: &Document, warning: &AnalysisWarning) -> Diagn
         None,
         warning.message.clone(),
         None,
-        None
+        None,
     )
 }
 

--- a/crates/yag-template-lsp/src/provider/diagnostics.rs
+++ b/crates/yag-template-lsp/src/provider/diagnostics.rs
@@ -1,5 +1,5 @@
-use tower_lsp::lsp_types::{Diagnostic, Url};
-use yag_template_analysis::AnalysisError;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Url};
+use yag_template_analysis::{AnalysisError, AnalysisWarning};
 use yag_template_syntax::SyntaxError;
 
 use crate::session::{Document, Session};
@@ -9,7 +9,11 @@ pub(crate) async fn publish(sess: &Session, uri: &Url) -> anyhow::Result<()> {
 
     let syntax_error_diags = doc.parse.errors.iter().map(|err| diag_for_syntax_error(&doc, err));
     let analysis_error_diags = doc.analysis.errors.iter().map(|err| diag_for_analysis_error(&doc, err));
-    let all_diags = syntax_error_diags.chain(analysis_error_diags).collect();
+    let analysis_warning_diags = doc.analysis.warnings.iter().map(|warning| diag_for_analysis_warning(&doc, warning));
+    let all_diags = syntax_error_diags
+                    .chain(analysis_error_diags)
+                    .chain(analysis_warning_diags)
+                    .collect();
 
     let version = Default::default();
     sess.client
@@ -24,6 +28,18 @@ fn diag_for_syntax_error(doc: &Document, err: &SyntaxError) -> Diagnostic {
 
 fn diag_for_analysis_error(doc: &Document, err: &AnalysisError) -> Diagnostic {
     Diagnostic::new_simple(doc.mapper.range(err.range), err.message.clone())
+}
+
+fn diag_for_analysis_warning(doc: &Document, warning: &AnalysisWarning) -> Diagnostic {
+    Diagnostic::new(
+        doc.mapper.range(warning.range),
+        Some(DiagnosticSeverity::WARNING),
+        None,
+        None,
+        warning.message.clone(),
+        None,
+        None
+    )
 }
 
 pub(crate) async fn clear(sess: &Session, uri: &Url) {


### PR DESCRIPTION
Same as #8, but with your help :-) also not using main as HEAD now.

Warn the user about unused variables. This was one of my biggest pain
points with reading/reviewing/writing yag code, such analysis should not
be done by a human. I'm open to suggestions if this should be less than
a warning (INFO, HINT); my first iteration had it error, but I decided
that was stupid.

This is one of the very few times I wrote Rust code, so any suggestions
are much appreciated, though I do think I did a reasonably good job with
the help of the Rust compiler.

Future work could probably entail some further abstraction(?), unsure
though. Like I said, basically zero Rust experience. It compiles, tests
pass, it works as I intended.

Go ham on it.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
