### PR TITLE
lsp: check for deprecated funcs

### DIFF
--- a/bundled-defs/README.md
+++ b/bundled-defs/README.md
@@ -34,6 +34,8 @@ Removes the specified role from the triggering members.
 - `delay`: An optional delay in seconds.
 ```
 
+A function can be marked as deprecated by adding a line starting with `Deprecated:` at the beginning of the docstring.
+
 Finally, as an organizational nicety, any lines starting with `==` will be ignored (acting effectively as comments). We
 conventionally use such lines to name and visually separate groups of related functions, but they can contain any
 content.

--- a/bundled-defs/context_funcs.ydef
+++ b/bundled-defs/context_funcs.ydef
@@ -356,8 +356,8 @@ func currentUserCreated()
 func onlineCount()
 	Returns the number of online members on the current server, including bots.
 
-func onlineCountBots() DEPRECATED
-	**Deprecated.** This function no longer works and will always return `0`.
+func onlineCountBots()
+	Deprecated: This function no longer works and will always return `0`.
 
 
 

--- a/bundled-defs/context_funcs.ydef
+++ b/bundled-defs/context_funcs.ydef
@@ -356,7 +356,7 @@ func currentUserCreated()
 func onlineCount()
 	Returns the number of online members on the current server, including bots.
 
-func onlineCountBots()
+func onlineCountBots() DEPRECATED
 	**Deprecated.** This function no longer works and will always return `0`.
 
 

--- a/bundled-defs/ext_plugin_funcs.ydef
+++ b/bundled-defs/ext_plugin_funcs.ydef
@@ -1,8 +1,8 @@
 == Logs plugin
-func pastUsernames(userID, offset)
+func pastUsernames(userID, offset) DEPRECATED
 	**Deprecated.** This function no longer works and will always return an error.
 
-func pastNicknames(userID, offset)
+func pastNicknames(userID, offset) DEPRECATED
 	**Deprecated.** This function no longer works and will always return an error.
 
 

--- a/bundled-defs/ext_plugin_funcs.ydef
+++ b/bundled-defs/ext_plugin_funcs.ydef
@@ -1,9 +1,9 @@
 == Logs plugin
-func pastUsernames(userID, offset) DEPRECATED
-	**Deprecated.** This function no longer works and will always return an error.
+func pastUsernames(userID, offset)
+	Deprecated: This function no longer works and will always return an error.
 
-func pastNicknames(userID, offset) DEPRECATED
-	**Deprecated.** This function no longer works and will always return an error.
+func pastNicknames(userID, offset)
+	Deprecated: This function no longer works and will always return an error.
 
 
 == Tickets plugin

--- a/bundled-defs/general_funcs.ydef
+++ b/bundled-defs/general_funcs.ydef
@@ -1,7 +1,7 @@
 == Type conversion
 func str(x)
 	Converts the input to a string, returning the empty string for invalid inputs. This function
-	is an alias of the `toString` function.
+	is an alias of the `toString` function, consider using that instead.
 
 func toString(x)
 	Converts the input to a string, returning the empty string for invalid inputs.

--- a/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
@@ -15,9 +15,7 @@ pub fn check(env: &EnvDefs, root: &ast::Root) -> Vec<AnalysisWarning> {
 fn check_func_call(env: &EnvDefs, call: ast::FuncCall) -> Option<AnalysisWarning> {
     let func_name_ident = call.func_name()?;
     let func_name = func_name_ident.get();
-    let Some(func) = env.funcs.get(func_name) else {
-        return None;
-    };
+    let func = env.funcs.get(func_name)?;
     func.is_deprecated
-        .then(|| AnalysisWarning::new(format!("{func_name} is deprecated"), func_name_ident.text_range(), true))
+        .then(|| AnalysisWarning::new_deprecation(format!("{func_name} is deprecated"), func_name_ident.text_range()))
 }

--- a/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
@@ -19,5 +19,5 @@ fn check_func_call(env: &EnvDefs, call: ast::FuncCall) -> Option<AnalysisWarning
         return None;
     };
     func.deprecated
-        .then(|| AnalysisWarning::new(format!("{func_name} is deprecated"), func_name_ident.text_range()))
+        .then(|| AnalysisWarning::new(format!("{func_name} is deprecated"), func_name_ident.text_range(), true))
 }

--- a/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
@@ -18,6 +18,6 @@ fn check_func_call(env: &EnvDefs, call: ast::FuncCall) -> Option<AnalysisWarning
     let Some(func) = env.funcs.get(func_name) else {
         return None;
     };
-    func.deprecated
+    func.is_deprecated
         .then(|| AnalysisWarning::new(format!("{func_name} is deprecated"), func_name_ident.text_range(), true))
 }

--- a/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
@@ -15,16 +15,9 @@ pub fn check(env: &EnvDefs, root: &ast::Root) -> Vec<AnalysisWarning> {
 fn check_func_call(env: &EnvDefs, call: ast::FuncCall) -> Option<AnalysisWarning> {
     let func_name_ident = call.func_name()?;
     let func_name = func_name_ident.get();
-    if let Some(func) = env.funcs.get(func_name) {
-        if func.deprecated {
-            Some(AnalysisWarning::new(
-                format!("{func_name} is deprecated"),
-                func_name_ident.text_range(),
-            ))
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+    let Some(func) = env.funcs.get(func_name) else {
+        return None;
+    };
+    func.deprecated
+        .then(|| AnalysisWarning::new(format!("{func_name} is deprecated"), func_name_ident.text_range()))
 }

--- a/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/deprecated_funcs.rs
@@ -1,0 +1,30 @@
+use yag_template_envdefs::EnvDefs;
+use yag_template_syntax::ast;
+use yag_template_syntax::ast::{AstNode, AstToken};
+
+use crate::AnalysisWarning;
+
+pub fn check(env: &EnvDefs, root: &ast::Root) -> Vec<AnalysisWarning> {
+    root.syntax()
+        .descendants()
+        .filter_map(ast::FuncCall::cast)
+        .filter_map(|call| check_func_call(env, call))
+        .collect()
+}
+
+fn check_func_call(env: &EnvDefs, call: ast::FuncCall) -> Option<AnalysisWarning> {
+    let func_name_ident = call.func_name()?;
+    let func_name = func_name_ident.get();
+    if let Some(func) = env.funcs.get(func_name) {
+        if func.deprecated {
+            Some(AnalysisWarning::new(
+                format!("{func_name} is deprecated"),
+                func_name_ident.text_range(),
+            ))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/crates/yag-template-analysis/src/checks/mod.rs
+++ b/crates/yag-template-analysis/src/checks/mod.rs
@@ -1,10 +1,2 @@
-use yag_template_envdefs::EnvDefs;
-use yag_template_syntax::ast;
-
-use crate::AnalysisError;
-
+pub mod deprecated_funcs;
 pub mod undefined_funcs;
-
-pub fn run_all(env: &EnvDefs, root: ast::Root) -> Vec<AnalysisError> {
-    undefined_funcs::check(env, root)
-}

--- a/crates/yag-template-analysis/src/checks/undefined_funcs.rs
+++ b/crates/yag-template-analysis/src/checks/undefined_funcs.rs
@@ -4,7 +4,7 @@ use yag_template_syntax::ast::{AstNode, AstToken};
 
 use crate::AnalysisError;
 
-pub fn check(env: &EnvDefs, root: ast::Root) -> Vec<AnalysisError> {
+pub fn check(env: &EnvDefs, root: &ast::Root) -> Vec<AnalysisError> {
     root.syntax()
         .descendants()
         .filter_map(ast::FuncCall::cast)

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -57,11 +57,19 @@ pub struct AnalysisWarning {
 }
 
 impl AnalysisWarning {
-    pub fn new(message: impl Into<String>, range: TextRange, is_deprecation: bool) -> Self {
+    pub fn new(message: impl Into<String>, range: TextRange) -> Self {
         Self {
             message: message.into(),
             range,
-            is_deprecation,
+            is_deprecation: false,
+        }
+    }
+
+    pub fn new_deprecation(message: impl Into<String>, range: TextRange) -> Self {
+        Self {
+            message: message.into(),
+            range,
+            is_deprecation: true,
         }
     }
 }

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -16,8 +16,9 @@ pub struct Analysis {
 }
 
 pub fn analyze(env: &EnvDefs, root: ast::Root) -> Analysis {
-    let (scope_info, mut errors, warnings) = scope::analyze(root.clone());
-    errors.extend(checks::run_all(env, root));
+    let (scope_info, mut errors, mut warnings) = scope::analyze(root.clone());
+    errors.extend(checks::undefined_funcs::check(env, &root));
+    warnings.extend(checks::deprecated_funcs::check(env, &root));
     Analysis {
         scope_info,
         errors,

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -13,16 +13,18 @@ pub struct Analysis {
     pub scope_info: ScopeInfo,
     pub errors: Vec<AnalysisError>,
     pub warnings: Vec<AnalysisWarning>,
+    pub deprecations: Vec<AnalysisWarning>,
 }
 
 pub fn analyze(env: &EnvDefs, root: ast::Root) -> Analysis {
-    let (scope_info, mut errors, mut warnings) = scope::analyze(root.clone());
+    let (scope_info, mut errors, warnings, mut deprecations) = scope::analyze(root.clone());
     errors.extend(checks::undefined_funcs::check(env, &root));
-    warnings.extend(checks::deprecated_funcs::check(env, &root));
+    deprecations.extend(checks::deprecated_funcs::check(env, &root));
     Analysis {
         scope_info,
         errors,
         warnings,
+        deprecations,
     }
 }
 

--- a/crates/yag-template-analysis/src/lib.rs
+++ b/crates/yag-template-analysis/src/lib.rs
@@ -13,18 +13,16 @@ pub struct Analysis {
     pub scope_info: ScopeInfo,
     pub errors: Vec<AnalysisError>,
     pub warnings: Vec<AnalysisWarning>,
-    pub deprecations: Vec<AnalysisWarning>,
 }
 
 pub fn analyze(env: &EnvDefs, root: ast::Root) -> Analysis {
-    let (scope_info, mut errors, warnings, mut deprecations) = scope::analyze(root.clone());
+    let (scope_info, mut errors, mut warnings) = scope::analyze(root.clone());
     errors.extend(checks::undefined_funcs::check(env, &root));
-    deprecations.extend(checks::deprecated_funcs::check(env, &root));
+    warnings.extend(checks::deprecated_funcs::check(env, &root));
     Analysis {
         scope_info,
         errors,
         warnings,
-        deprecations,
     }
 }
 
@@ -55,13 +53,15 @@ impl Error for AnalysisError {}
 pub struct AnalysisWarning {
     pub message: String,
     pub range: TextRange,
+    pub is_deprecation: bool,
 }
 
 impl AnalysisWarning {
-    pub fn new(message: impl Into<String>, range: TextRange) -> Self {
+    pub fn new(message: impl Into<String>, range: TextRange, is_deprecation: bool) -> Self {
         Self {
             message: message.into(),
             range,
+            is_deprecation,
         }
     }
 }

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -51,10 +51,7 @@ impl ScopeAnalyzer {
                 && !v.name.ends_with("_")
                 && let Some(decl_range) = v.decl_range
             {
-                warnings.push(AnalysisWarning::new_deprecation(
-                    format!("unused variable {}", v.name),
-                    decl_range,
-                ));
+                warnings.push(AnalysisWarning::new(format!("unused variable {}", v.name), decl_range));
             }
         }
         let info = ScopeInfo::new(self.var_syms, self.resolved_var_uses, self.scopes);

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -10,7 +10,14 @@ use yag_template_syntax::ast::{Action, AstNode, AstToken};
 use super::{Scope, ScopeId, ScopeInfo, VarSymbol, VarSymbolId};
 use crate::{AnalysisError, AnalysisWarning};
 
-pub fn analyze(root: ast::Root) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
+pub fn analyze(
+    root: ast::Root,
+) -> (
+    ScopeInfo,
+    Vec<AnalysisError>,
+    Vec<AnalysisWarning>,
+    Vec<AnalysisWarning>,
+) {
     let mut s = ScopeAnalyzer::new(root.text_range());
     // The variable $ is predefined as the initial context data.
     s.declare_var("$", root.text_range().start(), None);
@@ -26,6 +33,7 @@ struct ScopeAnalyzer {
     var_syms: SlotMap<VarSymbolId, VarSymbol>,
     resolved_var_uses: HashMap<TextRange, VarSymbolId>, // indexed by text range of ast::Var
     errors: Vec<AnalysisError>,
+    deprecations: Vec<AnalysisWarning>,
 }
 
 impl ScopeAnalyzer {
@@ -40,10 +48,18 @@ impl ScopeAnalyzer {
             var_syms: SlotMap::with_key(),
             resolved_var_uses: HashMap::new(),
             errors: Vec::new(),
+            deprecations: Vec::new(),
         }
     }
 
-    fn finish(self) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
+    fn finish(
+        self,
+    ) -> (
+        ScopeInfo,
+        Vec<AnalysisError>,
+        Vec<AnalysisWarning>,
+        Vec<AnalysisWarning>,
+    ) {
         assert!(self.parent_scopes.is_empty());
         let mut warnings = Vec::new();
         for v in self.var_syms.values() {
@@ -55,7 +71,7 @@ impl ScopeAnalyzer {
             }
         }
         let info = ScopeInfo::new(self.var_syms, self.resolved_var_uses, self.scopes);
-        (info, self.errors, warnings)
+        (info, self.errors, warnings, self.deprecations)
     }
 
     fn error(&mut self, message: impl Into<String>, range: TextRange) {

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -10,14 +10,7 @@ use yag_template_syntax::ast::{Action, AstNode, AstToken};
 use super::{Scope, ScopeId, ScopeInfo, VarSymbol, VarSymbolId};
 use crate::{AnalysisError, AnalysisWarning};
 
-pub fn analyze(
-    root: ast::Root,
-) -> (
-    ScopeInfo,
-    Vec<AnalysisError>,
-    Vec<AnalysisWarning>,
-    Vec<AnalysisWarning>,
-) {
+pub fn analyze(root: ast::Root) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
     let mut s = ScopeAnalyzer::new(root.text_range());
     // The variable $ is predefined as the initial context data.
     s.declare_var("$", root.text_range().start(), None);
@@ -33,7 +26,6 @@ struct ScopeAnalyzer {
     var_syms: SlotMap<VarSymbolId, VarSymbol>,
     resolved_var_uses: HashMap<TextRange, VarSymbolId>, // indexed by text range of ast::Var
     errors: Vec<AnalysisError>,
-    deprecations: Vec<AnalysisWarning>,
 }
 
 impl ScopeAnalyzer {
@@ -48,18 +40,10 @@ impl ScopeAnalyzer {
             var_syms: SlotMap::with_key(),
             resolved_var_uses: HashMap::new(),
             errors: Vec::new(),
-            deprecations: Vec::new(),
         }
     }
 
-    fn finish(
-        self,
-    ) -> (
-        ScopeInfo,
-        Vec<AnalysisError>,
-        Vec<AnalysisWarning>,
-        Vec<AnalysisWarning>,
-    ) {
+    fn finish(self) -> (ScopeInfo, Vec<AnalysisError>, Vec<AnalysisWarning>) {
         assert!(self.parent_scopes.is_empty());
         let mut warnings = Vec::new();
         for v in self.var_syms.values() {
@@ -67,11 +51,15 @@ impl ScopeAnalyzer {
                 && !v.name.ends_with("_")
                 && let Some(decl_range) = v.decl_range
             {
-                warnings.push(AnalysisWarning::new(format!("unused variable {}", v.name), decl_range));
+                warnings.push(AnalysisWarning::new(
+                    format!("unused variable {}", v.name),
+                    decl_range,
+                    false,
+                ));
             }
         }
         let info = ScopeInfo::new(self.var_syms, self.resolved_var_uses, self.scopes);
-        (info, self.errors, warnings, self.deprecations)
+        (info, self.errors, warnings)
     }
 
     fn error(&mut self, message: impl Into<String>, range: TextRange) {

--- a/crates/yag-template-analysis/src/scope/analysis.rs
+++ b/crates/yag-template-analysis/src/scope/analysis.rs
@@ -51,10 +51,9 @@ impl ScopeAnalyzer {
                 && !v.name.ends_with("_")
                 && let Some(decl_range) = v.decl_range
             {
-                warnings.push(AnalysisWarning::new(
+                warnings.push(AnalysisWarning::new_deprecation(
                     format!("unused variable {}", v.name),
                     decl_range,
-                    false,
                 ));
             }
         }

--- a/crates/yag-template-envdefs/src/lib.rs
+++ b/crates/yag-template-envdefs/src/lib.rs
@@ -145,11 +145,11 @@ fn process_source(defs: &mut EnvDefs, src: &EnvDefSource) -> Result<(), ParseErr
         } else if let Some(doc_line) = line.strip_prefix('\t') {
             match funcs.last_mut() {
                 Some((f, _)) => {
-                    f.doc.push_str(doc_line);
-                    f.doc.push('\n');
-                    if doc_line.starts_with("Deprecated:") {
+                    if doc_line.starts_with("Deprecated:") && f.doc.is_empty() {
                         f.is_deprecated = true;
                     }
+                    f.doc.push_str(doc_line);
+                    f.doc.push('\n');
                 }
                 None => bail!("unexpected indented line not part of function documentation", lineno),
             }

--- a/crates/yag-template-envdefs/src/lib.rs
+++ b/crates/yag-template-envdefs/src/lib.rs
@@ -19,11 +19,15 @@ pub struct Func {
     pub name: String,
     pub params: Vec<Param>,
     pub doc: String,
+    pub deprecated: bool,
 }
 
 impl Func {
     pub fn signature(&self) -> String {
         let mut buf = String::new();
+        if self.deprecated {
+            buf.push_str("DEPRECATED ");
+        }
         buf.push_str("func ");
         buf.push_str(&self.name);
 
@@ -217,11 +221,17 @@ fn parse_func_signature(line: &str) -> Result<Func, String> {
     ensure!(s.eat_if(')'), "expected ')' concluding parameter list");
 
     s.eat_whitespace();
+    let mut is_deprecated = false;
+    if s.eat_if("DEPRECATED") {
+        is_deprecated = true;
+    }
+    s.eat_whitespace();
     ensure!(s.done(), "expected line to end after parameter list");
     Ok(Func {
         name: name.into(),
         params,
         doc: String::new(),
+        deprecated: is_deprecated,
     })
 }
 

--- a/crates/yag-template-envdefs/src/lib.rs
+++ b/crates/yag-template-envdefs/src/lib.rs
@@ -25,9 +25,6 @@ pub struct Func {
 impl Func {
     pub fn signature(&self) -> String {
         let mut buf = String::new();
-        if self.is_deprecated {
-            buf.push_str("DEPRECATED ");
-        }
         buf.push_str("func ");
         buf.push_str(&self.name);
 

--- a/crates/yag-template-envdefs/src/lib.rs
+++ b/crates/yag-template-envdefs/src/lib.rs
@@ -19,13 +19,13 @@ pub struct Func {
     pub name: String,
     pub params: Vec<Param>,
     pub doc: String,
-    pub deprecated: bool,
+    pub is_deprecated: bool,
 }
 
 impl Func {
     pub fn signature(&self) -> String {
         let mut buf = String::new();
-        if self.deprecated {
+        if self.is_deprecated {
             buf.push_str("DEPRECATED ");
         }
         buf.push_str("func ");
@@ -150,6 +150,9 @@ fn process_source(defs: &mut EnvDefs, src: &EnvDefSource) -> Result<(), ParseErr
                 Some((f, _)) => {
                     f.doc.push_str(doc_line);
                     f.doc.push('\n');
+                    if doc_line.starts_with("Deprecated:") {
+                        f.is_deprecated = true;
+                    }
                 }
                 None => bail!("unexpected indented line not part of function documentation", lineno),
             }
@@ -221,17 +224,12 @@ fn parse_func_signature(line: &str) -> Result<Func, String> {
     ensure!(s.eat_if(')'), "expected ')' concluding parameter list");
 
     s.eat_whitespace();
-    let mut is_deprecated = false;
-    if s.eat_if("DEPRECATED") {
-        is_deprecated = true;
-    }
-    s.eat_whitespace();
     ensure!(s.done(), "expected line to end after parameter list");
     Ok(Func {
         name: name.into(),
         params,
         doc: String::new(),
-        deprecated: is_deprecated,
+        is_deprecated: false, // assume not deprecated at this stage
     })
 }
 

--- a/crates/yag-template-envdefs/src/lib.rs
+++ b/crates/yag-template-envdefs/src/lib.rs
@@ -145,9 +145,6 @@ fn process_source(defs: &mut EnvDefs, src: &EnvDefSource) -> Result<(), ParseErr
         } else if let Some(doc_line) = line.strip_prefix('\t') {
             match funcs.last_mut() {
                 Some((f, _)) => {
-                    if doc_line.starts_with("Deprecated:") && f.doc.is_empty() {
-                        f.is_deprecated = true;
-                    }
                     f.doc.push_str(doc_line);
                     f.doc.push('\n');
                 }
@@ -164,13 +161,24 @@ fn process_source(defs: &mut EnvDefs, src: &EnvDefSource) -> Result<(), ParseErr
     for (func, lineno) in funcs {
         match defs.funcs.entry(func.name.clone()) {
             Entry::Occupied(_) => bail!(format!("duplicate definition for function {}", func.name), lineno),
-            Entry::Vacant(entry) => entry.insert(Func {
-                doc: func.doc.trim().to_string(),
-                ..func
-            }),
+            Entry::Vacant(entry) => {
+                let trimmed_doc = func.doc.trim();
+                entry.insert(Func {
+                    doc: trimmed_doc.into(),
+                    is_deprecated: has_deprecation_marker(trimmed_doc),
+                    ..func
+                })
+            }
         };
     }
     Ok(())
+}
+
+fn has_deprecation_marker(docstr: &str) -> bool {
+    docstr
+        .lines()
+        .next()
+        .is_some_and(|first_line| first_line.starts_with("Deprecated:"))
 }
 
 macro_rules! ensure {

--- a/crates/yag-template-lsp/src/provider/diagnostics.rs
+++ b/crates/yag-template-lsp/src/provider/diagnostics.rs
@@ -14,15 +14,9 @@ pub(crate) async fn publish(sess: &Session, uri: &Url) -> anyhow::Result<()> {
         .warnings
         .iter()
         .map(|warning| diag_for_analysis_warning(&doc, warning));
-    let analysis_deprecation_diags = doc
-        .analysis
-        .deprecations
-        .iter()
-        .map(|deprecation| diag_for_deprecation_warning(&doc, deprecation));
     let all_diags = syntax_error_diags
         .chain(analysis_error_diags)
         .chain(analysis_warning_diags)
-        .chain(analysis_deprecation_diags)
         .collect();
 
     let version = Default::default();
@@ -48,19 +42,7 @@ fn diag_for_analysis_warning(doc: &Document, warning: &AnalysisWarning) -> Diagn
         None,
         warning.message.clone(),
         None,
-        None,
-    )
-}
-
-fn diag_for_deprecation_warning(doc: &Document, warning: &AnalysisWarning) -> Diagnostic {
-    Diagnostic::new(
-        doc.mapper.range(warning.range),
-        Some(DiagnosticSeverity::WARNING),
-        None,
-        None,
-        warning.message.clone(),
-        None,
-        Some(vec![DiagnosticTag::DEPRECATED]),
+        warning.is_deprecation.then(|| vec![DiagnosticTag::DEPRECATED]),
     )
 }
 

--- a/crates/yag-template-lsp/src/provider/diagnostics.rs
+++ b/crates/yag-template-lsp/src/provider/diagnostics.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, Url};
 use yag_template_analysis::{AnalysisError, AnalysisWarning};
 use yag_template_syntax::SyntaxError;
 
@@ -14,9 +14,15 @@ pub(crate) async fn publish(sess: &Session, uri: &Url) -> anyhow::Result<()> {
         .warnings
         .iter()
         .map(|warning| diag_for_analysis_warning(&doc, warning));
+    let analysis_deprecation_diags = doc
+        .analysis
+        .deprecations
+        .iter()
+        .map(|deprecation| diag_for_deprecation_warning(&doc, deprecation));
     let all_diags = syntax_error_diags
         .chain(analysis_error_diags)
         .chain(analysis_warning_diags)
+        .chain(analysis_deprecation_diags)
         .collect();
 
     let version = Default::default();
@@ -43,6 +49,18 @@ fn diag_for_analysis_warning(doc: &Document, warning: &AnalysisWarning) -> Diagn
         warning.message.clone(),
         None,
         None,
+    )
+}
+
+fn diag_for_deprecation_warning(doc: &Document, warning: &AnalysisWarning) -> Diagnostic {
+    Diagnostic::new(
+        doc.mapper.range(warning.range),
+        Some(DiagnosticSeverity::WARNING),
+        None,
+        None,
+        warning.message.clone(),
+        None,
+        Some(vec![DiagnosticTag::DEPRECATED]),
     )
 }
 


### PR DESCRIPTION
This enables the LSP to report deprecated functions as such, with an
inline warning to match. We already try to mark deprecated functions as
such within their docstrings in bundled-defs, but let's be real, nobody
reads those.
Instead, pop up a "nice" warning to annoy the user a little.

Deprecating `str` can be debated, though we did agree on NOT mentioning
it in favour of `toString` (which is in-line with every other type
conversion).

---
This is a combination of three commits:

* envdefs: support marking functions as deprecated

Add support for a "DEPRECATED" keyword coming *after* everything else on
the func definition line.

* analysis: analyse deprecated funcs

I also had to change the function signatures because of the borrow
checker. If you have suggestions for a neater approach, let me know.

* bundles-defs: mark deprecated functions as such
