### PR TITLE
workflows: small improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   language-server:
     strategy:
@@ -21,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
@@ -46,6 +51,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -9,6 +9,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     strategy:
@@ -54,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -80,10 +84,11 @@ jobs:
           args: '--release --locked'
 
       - name: Move binaries
+        shell: bash
         run: |
           mkdir -p editors/vscode/dist
-          cp "target/${{ matrix.rust-target }}/release/yag-template-lsp${{ env.BIN_EXT }}" editors/vscode/dist/
-          cp "target/${{ matrix.rust-target }}/release/yag-template-lsp${{ env.BIN_EXT }}" "yag-template-lsp-${{ matrix.rust-target }}${{ env.BIN_EXT }}"
+          cp "target/${{ matrix.rust-target }}/release/yag-template-lsp${BIN_EXT}" editors/vscode/dist/
+          cp "target/${{ matrix.rust-target }}/release/yag-template-lsp${BIN_EXT}" "yag-template-lsp-${{ matrix.rust-target }}${BIN_EXT}"
 
       - name: Package VSCode extension
         shell: bash

--- a/.github/workflows/new-funcs.yml
+++ b/.github/workflows/new-funcs.yml
@@ -5,6 +5,8 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   detect-missing-funcs:
     name: Check for new template functions
@@ -16,6 +18,8 @@ jobs:
       LYTFS_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
           omitPrereleaseDuringUpdate: true
+          generateReleaseNotes: true
 
   publish-vscode:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
   build:
     uses: ./.github/workflows/full-build.yml
@@ -19,8 +21,7 @@ jobs:
     needs: [build]
     if: success() && startsWith(github.ref, 'refs/tags/')
     permissions:
-      # needed to create releases
-      contents: write
+      contents: write # needed to create releases
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
As discussed in direct messages. I also ran the workflows past Zizmor
to catch some opportunities to harden them, primarily focussed on overly
broad `GITHUB_TOKEN` permissions.

I don't think we need to cut a release for this one, instead we should
wait for a few new features to the LSP itself. I ran everything except
the Publish workflow on my fork, no issues were reported and artifacts
were uploaded correctly as well.

----

* workflows/release: generate release notes

  This will populate the release notes with generated ones using GitHub's
  generator which makes use of the PR titles that went into said release.

* workflows: harden with zizmor

  Harden some parts of the workflows by passing them over to zizmor -- the
  CLI flags a few more things like unpinned action references, but we
  don't care about those (for now).

